### PR TITLE
Changed include of hero-front-end.php

### DIFF
--- a/wordpress-blocks/wp-blocks.php
+++ b/wordpress-blocks/wp-blocks.php
@@ -217,7 +217,7 @@ if( ! class_exists('wp_blocks') ) :
 								if( get_row_layout() == 'hero' ):
 
 									// Get the file /inc/partials/hero.php (which contains the relevant block layouts)
-									include_once( 'inc/partials/hero-front-end.php' );
+									include( 'inc/partials/hero-front-end.php' );
 
 								endif;
 


### PR DESCRIPTION
If two identical blocks are used in succession and the front end file is called via `include_once` only the first block is shown on the front end. That's why `include` must be used here.